### PR TITLE
Fixed vsearch version issue, and sorting of reads

### DIFF
--- a/Emirge/clustering.py
+++ b/Emirge/clustering.py
@@ -1,5 +1,5 @@
 import re
-from subprocess import check_output
+from subprocess import check_output, PIPE, Popen
 
 from Emirge.io import command_avail, check_call
 from Emirge.log import CRITICAL
@@ -15,8 +15,8 @@ class vsearch(object):
         if not command_avail(cls.binary):
             return False
 
-        out = check_output([cls.binary, "--version"])
-        match = re.search('vsearch.* v([0-9]*)\.([0-9]*)\.([0-9]*)', out)
+        out = Popen([cls.binary, "--version"], stdout = PIPE, stderr = PIPE)
+        match = re.search('vsearch.* v([0-9]*)\.([0-9]*)\.([0-9]*)', out.communicate()[1])
         version = tuple(int(x) for x in match.groups())
 
         if version < (1,1,0):

--- a/emirge_rename_fasta.py
+++ b/emirge_rename_fasta.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/home/linuxbrew/.linuxbrew/Cellar/python/2.7.12_1/bin/python
 """
 EMIRGE: EM Iterative Reconstruction of Genes from the Environment
 Copyright (C) 2010-2016 Christopher S. Miller  (christopher.s.miller@ucdenver.edu)
@@ -137,7 +137,7 @@ def rename(wd=os.getcwd(), output_file="renamed.fasta", record_prefix='',
                              prior, len(record.seq), normed_priors[i])
 
     renamed_fasta_file = open(output_file, 'w')
-    for prior, record in sorted(sorted_records, reverse=True):
+    for prior, record in sorted(sorted_records, key=lambda prior: prior[0], reverse=True):
         if prior < prob_min:
             break
         SeqIO.write(record, renamed_fasta_file, 'fasta')


### PR DESCRIPTION
This fixes the following problems:
1. `vsearch` version is not properly parsed, causing the program to crash. `vsearch` prints version to stderr, which was not captured with `subprocess.check_output`. So, changed to `subprocess.Popen`.
2. in `emirge_rename_fasta.py` there was an issue with sorting a list of tuples [(prior, seqrecord)] where `sorted` tries to sort by all the elements of each tuple, but there is no `__comp__` method for SeqRecords. This is fixed by setting the key to sort only on the prior.

The code now seems to work to completion, at least in the data I tried.

Anders.
