### PR TITLE
Fix for the "Illegal header line in fasta file" error.

### DIFF
--- a/emirge_makedb.py
+++ b/emirge_makedb.py
@@ -412,6 +412,8 @@ def main(argv=sys.argv[1:]):
         downloader.license_confirmed = options.license
         silva_fasta = downloader.run(options.gene, options.release,
                                      options.tmpdir)
+        subprocess.call(["gunzip", silva_fasta])
+        silva_fasta = silva_fasta.replace(".gz", "")
         clustered_fasta = cluster_fasta(options.vsearch, silva_fasta,
                                         options.min_len, options.max_len,
                                         options.clusterid, options.threads)


### PR DESCRIPTION
After downloading SILVA_128_SSURef_Nr99_tax_silva_trunc.fasta.gz, the script tried to read it directly, resulting in the fatal error "Illegal header line in fasta file (not starting with '>' character)." With this change the file is extracted before reading.